### PR TITLE
Update thevid_gmu.py

### DIFF
--- a/lib/urlresolver/plugins/thevid_gmu.py
+++ b/lib/urlresolver/plugins/thevid_gmu.py
@@ -22,5 +22,5 @@ logger = common.log_utils.Logger.get_logger(__name__)
 logger.disable()
 
 def get_media_url(url):
-    return helpers.get_media_url(url, patterns=[''';var\srick=["'](?P<url>http://[^'"]+)'''], result_blacklist=['logger', 'iframe', 'r.mp4', 'a.mp4', 'c.mp4', 'url'], generic_patterns=False ).replace(' ', '%20')
-     
+    return helpers.get_media_url(url, patterns=['''var\srick=["'](?P<url>http://[^'"]+)'''], result_blacklist=['logger', 'iframe', 'r.mp4', 'a.mp4', 'c.mp4'], generic_patterns=False ).replace(' ', '%20')
+    


### PR DESCRIPTION
TheVid re-arranges the variables on each different page load. On the rare chance the URL in the video was first, the regex would fail to pick it up due to having no semi-colon before. I also forgot to remove 'url' from the blacklist as it was not needed in the end.