### PR TITLE
Use default scrapers

### DIFF
--- a/lib/urlresolver/plugins/vkprime.py
+++ b/lib/urlresolver/plugins/vkprime.py
@@ -39,7 +39,7 @@ class VkPrimeResolver(UrlResolver):
         
         if r:
             html = jsunpack.unpack(r.group(1))
-            sources = helpers.scrape_sources(html, patterns=[r'''file:\s*"(?P<url>[^"]+)'''], generic_patterns=False)
+            sources = helpers.scrape_sources(html)
             if sources:
                 return helpers.pick_source(sources) + helpers.append_headers(headers)
 


### PR DESCRIPTION
The custom pattern that was passed to helpers.scrape_sources() was not returning video URLs sorted by quality. And the custom pattern seemed to be redundant. 